### PR TITLE
fix remove_prefix

### DIFF
--- a/mixamoroot.py
+++ b/mixamoroot.py
@@ -160,9 +160,9 @@ def add_root_bone(root_bone_name="Root", hip_bone_name="mixamorig:Hips", remove_
     armature.data.edit_bones[hip_bone_name].parent = armature.data.edit_bones[name_prefix + root_bone_name]
     bpy.ops.object.mode_set(mode='OBJECT')
 
-    fixBones(remove_prefix=remove_prefix, name_prefix=name_prefix)
     scaleAll()
     copyHips(root_bone_name=root_bone_name, hip_bone_name=hip_bone_name, name_prefix=name_prefix)
+	fixBones(remove_prefix=remove_prefix, name_prefix=name_prefix)
 
 def push(obj, action, track_name=None, start_frame=0):
     # Simulate push :


### PR DESCRIPTION
I've moved the deletion of bone name prefixes. The copyHips function works with bone names including the prefix. This seems like a simple solution to me.